### PR TITLE
add o-blog-pkg.el

### DIFF
--- a/o-blog-pkg.el
+++ b/o-blog-pkg.el
@@ -1,0 +1,4 @@
+(define-package 
+  "o-blog"
+  "1.2"
+  "Org-blog exporter")


### PR DESCRIPTION
Emacs24 now includes a Lisp-based package manager.
It recognize One of the files in the content directory must be named "NAME-pkg.el"
In detail, see `(info "(elisp) Packaging")` or  [marmalade package manual](http://marmalade-repo.org/doc-files/package.5.html). 
this commit enables us to install o-blog via package manager.
