### PR TITLE
Add an article div 

### DIFF
--- a/templates/blog_post-by-tags.html
+++ b/templates/blog_post-by-tags.html
@@ -1,5 +1,5 @@
 <lisp>(ob:insert-template "page_header.html")</lisp>
-<article>
+<div class="article">
   <header class="article-header">
     <div class="well">
       <div class="row">
@@ -28,5 +28,5 @@
       </div>
     </nav>
   </div>
-</article>
-<lisp>(ob:insert-template "page_footer.html")</lisp>    
+</div>
+<lisp>(ob:insert-template "page_footer.html")</lisp>

--- a/templates/blog_post.html
+++ b/templates/blog_post.html
@@ -1,4 +1,5 @@
 <lisp>(ob:insert-template "page_header.html")</lisp>
+  <div class="article">
   <header class="article-header">
 
     <div class="well">
@@ -68,5 +69,6 @@
       </ul>
     </nav>
   </footer>
+  </div>
   <lisp>(ob:insert-template "plugin_disqus.html")</lisp>
 <lisp>(ob:insert-template "page_footer.html")</lisp>


### PR DESCRIPTION
This commit adds an article div to templates.  Having an article or a content div, makes the page parse-able by the code on Google+ and the links can be shared on Google plus.  Without those divs, the whole page gets shared, which essentially shows the content in the header. 
