### PR TITLE
Make the qrcode plugin optional

### DIFF
--- a/o-blog.el
+++ b/o-blog.el
@@ -136,6 +136,11 @@ This is a good place for o-blog parser plugins."
  - post-htmlfile: a 3-argument function to be used to generate
    the post html filename in output directory. Defined by
    \"#+POSTS_HTMLFILE:\" or \"ob-set-default-htmlfile\".
+
+ - plugin-qrcode: \"t\" or \"nil\". Enables the plugin-qrcode
+   that uses chart.apis.google.com. Default is \"t\" for backward
+   compatibility.  Defined by the \"#PLUGIN_QRCODE\" header.
+
 "
   (file nil :read-only)
   (buffer nil :read-only)
@@ -157,7 +162,8 @@ This is a good place for o-blog parser plugins."
   filename-sanitizer
   posts-sorter
   posts-filepath
-  posts-htmlfile)
+  posts-htmlfile
+  plugin-qrcode)
 
 
 (defstruct (ob:post :named)
@@ -519,6 +525,7 @@ A copy function COPYF and its arguments ARGS could be specified."
     (setf (ob:blog-default-category blog) (or (ob:get-header "DEFAULT_CATEGORY") "Blog"))
     (setf (ob:blog-disqus blog) (ob:get-header "DISQUS"))
     (setf (ob:blog-analytics blog) (ob:get-header "ANALYTICS"))
+    (setf (ob:blog-plugin-qrcode blog) (string-equal (or (ob:get-header "PLUGIN_QRCODE") "t") "t"))
     (setf (ob:blog-filename-sanitizer blog)
 	  (let ((ofs (ob:get-header "FILENAME_SANITIZER")))
 	    (if (and ofs (functionp (intern ofs)))

--- a/templates/blog_post-by-tags.html
+++ b/templates/blog_post-by-tags.html
@@ -4,7 +4,7 @@
     <div class="well">
       <div class="row">
 	<div class="span1">
-	  <lisp>(ob:insert-template "plugin_qrcode.html")</lisp>
+	  <lisp>(when (ob:blog-plugin-qrcode BLOG) (ob:insert-template "plugin_qrcode.html"))</lisp>
 	</div>
 	<h1 class="offset1" style="font-size: 250%;"><lisp>(ob:post-title POST)</lisp></h1>
       </div>

--- a/templates/blog_post.html
+++ b/templates/blog_post.html
@@ -24,7 +24,7 @@
 	  </div>
 	</div>
 	<div class="span1">
-	  <lisp>(ob:insert-template "plugin_qrcode.html")</lisp>
+	  <lisp>(when (ob:blog-plugin-qrcode BLOG) (ob:insert-template "plugin_qrcode.html"))</lisp>
 	</div>
 	<h1 class="offset2" style="font-size: 250%"><lisp>(ob:post-title POST)</lisp></h1>
       </div>

--- a/templates/blog_static.html
+++ b/templates/blog_static.html
@@ -4,7 +4,7 @@
     <div class="well">
       <div class="row">
 	<div class="span1">
-	  <lisp>(ob:insert-template "plugin_qrcode.html")</lisp>
+	  <lisp>(when (ob:blog-plugin-qrcode BLOG) (ob:insert-template "plugin_qrcode.html"))</lisp>
 	</div>
 	<h1 class="offset1" style="font-size: 250%;"><lisp>(ob:post-title POST)</lisp></h1>
       </div>


### PR DESCRIPTION
This patch make the plugin-qrcode optional.

In fact the purpose of a plugin is to be enable or disabled
depending on user needs. Or not?

By default is backward compatible.
